### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Provide the latest cryptocurrency news to AI agents, powered by [CryptoPanic](https://cryptopanic.com/).
 
+<a href="https://glama.ai/mcp/servers/dp6kztv7yx">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/dp6kztv7yx/badge" alt="cryptopanic-mcp-server MCP server" />
+</a>
+
 ## Tools
 
 The server implements only one tool: 


### PR DESCRIPTION
This PR adds a badge for the [cryptopanic-mcp-server](https://glama.ai/mcp/servers/dp6kztv7yx) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/dp6kztv7yx">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/dp6kztv7yx/badge" alt="cryptopanic-mcp-server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.